### PR TITLE
Update sensor.py to lowercase latitude / longitude

### DIFF
--- a/custom_components/project_zero_three/sensor.py
+++ b/custom_components/project_zero_three/sensor.py
@@ -14,8 +14,8 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_LATITUDE = "Latitude"
-ATTR_LONGITUDE = "Longitude"
+ATTR_LATITUDE = "latitude"
+ATTR_LONGITUDE = "longitude"
 
 
 CONF_UPDATE_FREQUENCY = 'update_frequency'


### PR DESCRIPTION
Change the attrributes of Lattitude and Longitude to lowercase, to allow the sensor to be compatible with the new Map functions in 2023.10
https://www.home-assistant.io/blog/2023/10/04/release-202310/#map-entity-marker-options