### PR TITLE
Added Entities for ALL States

### DIFF
--- a/custom_components/project_zero_three/sensor.py
+++ b/custom_components/project_zero_three/sensor.py
@@ -63,32 +63,31 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         message = "Error: {}. Check the logs for additional information.".format(
             data.error
         )
-
+        
         hass.components.persistent_notification.create(
             message, title=NOTIFICATION_TITLE, notification_id=NOTIFICATION_ID
         )
         return
 
-    available_fuel_types = data.get_available_fuel_types()
-
-    add_entities(
-        [
-            StationPriceSensor(data, fuel_type)
+    entities = []
+    for region in data.get_regions():
+        available_fuel_types = data.get_available_fuel_types(region)
+        
+        entities.extend(
+            StationPriceSensor(data, fuel_type, region)
             for fuel_type in fuel_types
             if fuel_type in available_fuel_types
-        ]
-    )
-
+        )
+    
+    add_entities(entities)
 
 class FuelPriceData:
-    """An object to store and fetch the latest data for a given station."""
+    """An object to store and fetch the latest data for multiple regions."""
 
     def __init__(self) -> None:
         """Initialize the sensor."""
         self._data = None
-        self._reference_data = None
         self.error = None
-        self._station_name = None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
@@ -96,79 +95,76 @@ class FuelPriceData:
         try:
             res = requests.get(
                 "https://projectzerothree.info/api.php?format=json",
-                headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, '
-                                       'like Gecko) Chrome/80.0.3987.0 Safari/537.36 Edg/80.0.360.0'}
+                headers={'User-Agent': 'Mozilla/5.0'}
             )
-
-            self._data = res.json()['regions'][0]['prices']
+            self._data = res.json()['regions']
         except requests.RequestException as exc:
             self.error = str(exc)
             _LOGGER.error("Failed to fetch project zero three price data. %s", exc)
-
-    def for_fuel_type(self, fuel_type: str):
-        """Return the price of the given fuel type."""
+    
+    def get_regions(self):
+        """Return the list of regions."""
         if self._data is None:
+            return []
+        return [region['region'] for region in self._data]
+
+    def get_available_fuel_types(self, region_name):
+        """Return the available fuel types for a given region."""
+        region_data = next((r for r in self._data if r['region'] == region_name), None)
+        if not region_data:
+            return []
+        return [price['type'] for price in region_data['prices']]
+
+    def for_fuel_type(self, fuel_type: str, region_name: str):
+        """Return the price of the given fuel type in a specific region."""
+        region_data = next((r for r in self._data if r['region'] == region_name), None)
+        if not region_data:
             return None
-        return next(
-            (price for price in self._data if price['type'] == fuel_type), None
-        )
-
-    def get_available_fuel_types(self):
-        """Return the available fuel types for the station."""
-        return [price['type'] for price in self._data]
-
+        return next((price for price in region_data['prices'] if price['type'] == fuel_type), None)
 
 class StationPriceSensor(Entity):
-
     """Implementation of a sensor that reports the fuel price for a station."""
 
-    def __init__(self, data: FuelPriceData, fuel_type: str):
+    def __init__(self, data: FuelPriceData, fuel_type: str, region: str):
         """Initialize the sensor."""
         self._data = data
         self._fuel_type = fuel_type
+        self._region = region
 
     def get_price_data(self) -> Optional[dict]:
         """Return the state of the sensor."""
-        price_info = self._data.for_fuel_type(self._fuel_type)
-        if price_info:
-            return price_info
-
-        return None
+        return self._data.for_fuel_type(self._fuel_type, self._region)
 
     @property
     def unique_id(self) -> Optional[str]:
-        """Return the name of the sensor."""
+        """Return the unique ID of the sensor."""
         data = self.get_price_data()
-        return f"project_zero_three_{data['type']}"
+        if self._region == "All":
+            return f"project_zero_three_{data['type']}"
+        return f"project_zero_three_{data['type']}_{self._region}"
 
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
         data = self.get_price_data()
-
         if not self.registry_entry:
             return self.unique_id
-
         return f"{data['type']} @ {data['suburb']} {data['postcode']} ({data['state']})"
 
     @property
     def state(self) -> Optional[float]:
         """Return the state of the sensor."""
         data = self.get_price_data()
-        if data:
-            return data['price']
-
-        return None
+        return data['price'] if data else None
 
     @property
     def extra_state_attributes(self) -> dict:
         """Return the state attributes of the device."""
         data = self.get_price_data()
-
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            ATTR_LATITUDE: data['lat'] or None,
-            ATTR_LONGITUDE: data['lng'] or None
+            ATTR_LATITUDE: data['lat'] if data else None,
+            ATTR_LONGITUDE: data['lng'] if data else None,
         }
 
     @property


### PR DESCRIPTION
Have updated the script to pull data for all states.
The "all" region still uses the same entity id for backwards compatibility.

Ie. Best Diesel price anywhere will still be "sensor.project_zero_three_diesel" but there is also now entities for "sensor.project_zero_three_diesel_vic", "sensor.project_zero_three_diesel_wa" etc for best prices in a particular state.

It will also pull the second and third best prices appending _2 and _3 to the above.
Exception to this is the all regions which are "all_2" and "all_3".